### PR TITLE
Switch from rtm.start (deprecated API) to rtm.connect

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -155,13 +155,17 @@ module Lita
             SlackChannel.from_data_array(groups_list["groups"])
           )
 
-          TeamData.new(
+          Lita.logger.debug("Start building rtm_start TeamData")
+          team_data = TeamData.new(
             SlackIM.from_data_array(im_list["ims"]),
             SlackUser.from_data(rtm_connect_response["self"]),
             SlackUser.from_data_array(users_list["members"]),
             channels,
             rtm_connect_response["url"]
           )
+          Lita.logger.debug("Done building rtm_start TeamData")
+
+          team_data
         end
 
         private
@@ -171,14 +175,14 @@ module Lita
         attr_reader :post_message_config
 
         def call_api(method, post_data = {})
-          Lita.logger.debug("Starting request to Slack API with rtm.start")
+          Lita.logger.debug("Making Slack API request: #{method}")
           response = connection.post(
             "https://slack.com/api/#{method}",
             { token: config.token }.merge(post_data)
           )
-          Lita.logger.debug("Finished request to Slack API rtm.start")
+          Lita.logger.debug("Finished Slack API request: #{method}")
           data = parse_response(response, method)
-          Lita.logger.debug("Finished parsing rtm.start response")
+          Lita.logger.debug("Finished parsing #{method} response")
           raise "Slack API call to #{method} returned an error: #{data["error"]}." if data["error"]
 
           data

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -798,8 +798,24 @@ describe Lita::Adapters::Slack::API do
     let(:http_status) { 200 }
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('https://slack.com/api/rtm.start', token: token) do
+        stub.post('https://slack.com/api/rtm.connect', token: token) do
           [http_status, {}, http_response]
+        end
+
+        stub.post('https://slack.com/api/users.list', token: token) do
+          [http_status, {}, MultiJson.dump({ok: true, members: [ id: "U023BECGF"]})]
+        end
+
+        stub.post('https://slack.com/api/conversations.list', token: token, types: 'public_channel') do
+          [http_status, {}, MultiJson.dump({ok: true, channels: [{id: 'C024BE91L'}]})]
+        end
+
+        stub.post('https://slack.com/api/conversations.list', token: token, types: 'private_channel') do
+          [http_status, {}, MultiJson.dump({ok: true, channels: [{id: 'G024BE91L'}]})]
+        end
+
+        stub.post('https://slack.com/api/conversations.list', token: token, types: 'im') do
+          [http_status, {}, MultiJson.dump({ok: true, channels: [{id: "D024BFF1M"}]})]
         end
       end
     end
@@ -809,11 +825,12 @@ describe Lita::Adapters::Slack::API do
         MultiJson.dump({
           ok: true,
           url: 'wss://example.com/',
-          users: [{ id: 'U023BECGF' }],
-          ims: [{ id: 'D024BFF1M' }],
           self: { id: 'U12345678' },
-          channels: [{ id: 'C1234567890' }],
-          groups: [{ id: 'G0987654321' }],
+          team: {
+            id: "T0ABC12DE",
+            name: "Foobar",
+              "domain": "foobar"
+          }
         })
       end
 


### PR DESCRIPTION
Slack has deprecated the `rtm.start` API and in a few days the response it returns will remove a lot of info that we are currently relying on:

  https://api.slack.com/changelog/2021-10-rtm-start-to-stop

This change switches to `rtm.connect` to start the session, and then makes requests to other APIs to get the additional info we require.