### PR TITLE
Add faye monkeypatch to fix x509 certificate verification

### DIFF
--- a/lib/lita/adapters/slack/faye_monkeypatch.rb
+++ b/lib/lita/adapters/slack/faye_monkeypatch.rb
@@ -1,0 +1,31 @@
+# patch faye's ssl verification so that it works with newer
+# Let's Encrypt certs, adapted from:
+#   https://github.com/igrigorik/em-http-request/pull/352
+# More info from original author:
+#   Every LetsEncrypt issued signature chain now starts with an expired certificate,
+#   but the second item in the chain is a trusted root. So instead of failing the
+#   whole validation for any link in the chain failing, just don't add failed links
+#   to the store, then make sure the final certificate is valid given whatever was
+#   added to the store.
+
+module Faye
+  class WebSocket
+    class SslVerifier
+      def ssl_verify_peer(cert_text)
+        return true unless should_verify?
+
+        certificate = parse_cert(cert_text)
+        return false unless certificate
+
+        store_cert(certificate) if @cert_store.verify(certificate)
+        @last_cert = certificate
+
+        true
+      end
+
+      def identity_verified?
+        @last_cert && @cert_store.verify(@last_cert) && OpenSSL::SSL.verify_certificate_identity(@last_cert, @hostname)
+      end
+    end
+  end
+end

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -1,6 +1,8 @@
 require 'faye/websocket'
 require 'multi_json'
 
+require 'lita/adapters/slack/faye_monkeypatch'
+
 require 'lita/adapters/slack/api'
 require 'lita/adapters/slack/event_loop'
 require 'lita/adapters/slack/im_mapping'


### PR DESCRIPTION
Last week Slack updated the cert for their API and this broke the bot. Seems like the new Let's Encrypt cert they're using could not be verified by the existing ad hoc cert verification code in faye, maybe because we are still using the second certification path (see the qualys ssl report for wss-primary.slack.com) which has an expired cert in the chain, not sure. But as you can see in the comments in the monkeypatch file, other people have run into this problem and I was able to grab their patch, seems to work.

I think this could be an example of why people say 'don't roll your own crypto'.